### PR TITLE
Remove the context to work on the newer Django versions

### DIFF
--- a/django_live_log/views.py
+++ b/django_live_log/views.py
@@ -18,7 +18,7 @@ def log_streamer(request, from_=0, file_path=None):
                     result = f.read()
                     last = f.tell()
                     t = loader.get_template('django_live_log/main.html')
-                    yield t.render(Context({"result": result}))
+                    yield t.render({"result": result})
                 except IOError:
                     start += 50
         reset = 0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django_live_log',
-    version='1.1.3',
+    version='1.1.4',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',  # example license


### PR DESCRIPTION
Context is not working on newer Django version
By just removing it works fine.